### PR TITLE
OVH - Change domain zones URL to remove leading /

### DIFF
--- a/lexicon/providers/ovh.py
+++ b/lexicon/providers/ovh.py
@@ -58,7 +58,7 @@ class Provider(BaseProvider):
     def authenticate(self):
         domain = self.options.get('domain')
 
-        domains = self._get('/domain/zone/')
+        domains = self._get('/domain/zone')
         if domain not in domains:
             raise Exception('Domain {0} not found'.format(domain))
 


### PR DESCRIPTION
Removing leading / from OVH domain zones list URL to stick more strictly to OVH API Docs.

Making this change because lot of people are creating tokens with strict permissions and they often will refer to OVH API docs or other sources how to set correct permissions. Unfortunately, creating permission with `/domain/zone` URL won't allow to access `/domain/zone/` despite of they both doing the same work.